### PR TITLE
Add site.asset() helper for inlining assets

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -21,6 +21,7 @@ var Generator = module.exports = function(files, config, cb) {
   self.cb = cb;
 
   config.asset_path = this.asset_path.bind(this);
+  config.asset = this.asset.bind(this);
 
   this.config = config;
 
@@ -218,6 +219,12 @@ Generator.prototype.renderEJS = function(file, cb) {
 
     cb(err, html);
   });
+};
+
+Generator.prototype.asset = function(path) {
+  var path = this.asset_path(path);
+
+  return fs.readFileSync(_site + path).toString();
 };
 
 Generator.prototype.asset_path = function(path) {


### PR DESCRIPTION
Probably not the most elegant way of doing it but this allows for something like:

``` html
<script><%- site.asset('/js/foo.js') %></script>
```

or

``` html
<style><%- site.asset('/css/bar.css') %></style>
```

... for when you want the assets to be inlined (like, oh I dunno, an error page where all the essential scripts and styles should be on the page itself rather than in separate files that may fail to load)
