### PR TITLE
Add autoprefixer for CSS, swap sqwish for better clean-css

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -3,7 +3,8 @@ var fs = require('fs-extra');
 var crypto = require('crypto');
 var Mincer = require('mincer');
 
-var sqwish = require('sqwish');
+var autoprefixer = require('autoprefixer');
+var cleanCss = require('clean-css');
 var UglifyJS = require("uglify-js");
 var htmlminify = require('html-minifier').minify;
 
@@ -155,7 +156,8 @@ Generator.prototype.compile = function(file, asset, cb) {
     var info = ass.toString();
 
     if (file.extension === 'less' || file.extension === 'css') {
-      info = sqwish.minify(info);
+      info = autoprefixer.process(info).css;
+      info = cleanCss().minify(info);
       return cb(info);
     }
 

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
     "send": "~0.1.0",
     "less": "~1.3.3",
     "mincer": "~0.4.6",
-    "sqwish": "~0.2.1",
     "uglify-js": "~2.3.6",
     "html-minifier": "~0.5.2",
     "walkdir": "0.0.7",
-    "ejs2": "~2.1.0"
+    "ejs2": "~2.1.0",
+    "clean-css": "~2.0.7",
+    "autoprefixer": "~1.0.20140117"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
This might need a little bit more thorough testing than I've given it, but it seems to work for me.

Two things here:
- Add [autoprefixer](//github.com/ai/autoprefixer) to CSS compilation for automatic vendor prefixes and expansion of things like keyframes
- Swap sqwish for [clean-css](https://github.com/GoalSmashers/clean-css) because it produces smaller outputs and is a bit more intelligent than sqwish.
