### PR TITLE
Queue jobs when workers are saturated rather than failing

### DIFF
--- a/lib/Generator.js
+++ b/lib/Generator.js
@@ -17,6 +17,8 @@ var Generator = module.exports = function(config) {
   self.asset_paths = {};
   self.cbs = {};
 
+  self.queue = [];
+
   if (cluster.isMaster) self.spawnWorkers();
 };
 
@@ -42,8 +44,13 @@ Generator.prototype.spawnWorkers = function() {
         for (var i in msg.asset_paths) self.asset_paths[i] = msg.asset_paths[i];
       }
       if (msg.file) {
-        self.freeWorkers.push(this);
         if (self.cbs[msg.file]) self.cbs[msg.file](msg.err);
+
+        if (self.queue.length) {
+          this.send(self.queue.shift());
+        } else {
+          self.freeWorkers.push(this);
+        }
       }
     });
   }
@@ -98,17 +105,22 @@ Generator.prototype.process = function(files, cb) {
 Generator.prototype.processFile = function(file, liveGen, cb) {
   var self = this;
 
-  if (!self.freeWorkers.length) return cb('no workers');
-
-  self.freeWorkers.shift().send({
+  var msg = {
     asset_paths: self.asset_paths,
     file: file,
     liveGen: liveGen
-  });
+  };
+
   self.cbs[file] = function() {
     delete self.cbs[file];
     cb();
   };
+
+  if (!self.freeWorkers.length) {
+    self.queue.push(msg);
+  } else {
+    self.freeWorkers.shift().send(msg);
+  }
 };
 
 Generator.prototype.deleteSite = function(cb) {
@@ -139,4 +151,3 @@ Generator.prototype.asset_path = function(path, noHost) {
 
   return this.asset_paths[path] ? (noHost ? '' : this.config.asset_host) + this.asset_paths[path] : path;
 };
-


### PR DESCRIPTION
Workers pull from the queue when they're done if anything's pending, rather than pushing themselves straight back onto freeWorkers.

Also fix silly case-sensitivity thingy with Generator.js
